### PR TITLE
fix migrator class deprecation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ namespace :db do
   task :migrate do
     connection_details = YAML::load(File.open('config/database.yml'))
     ActiveRecord::Base.establish_connection(connection_details)
-    ActiveRecord::Migrator.migrate('db/migrate/')
+    ActiveRecord::Migration.migrate('db/migrate/')
   end
 
   desc 'Create the database'


### PR DESCRIPTION
since Rails 5.2 Migrator methods had moved to Migration class
https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/migration.rb#L1159